### PR TITLE
Remove calibration offset

### DIFF
--- a/src/hx711.rs
+++ b/src/hx711.rs
@@ -155,7 +155,7 @@ impl<'d> Hx711<'d> {
         debug!("Updating calibration factor: {}", factor);
         Self::write_to_flash(factor)?;
 
-        (*self).calibration_factor = factor;
+        self.calibration_factor = factor;
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,6 +178,7 @@ async fn measurement_task(
     delay: Delay,
 ) {
     let mut load_cell = Hx711::new(data_pin, clock_pin, delay);
+    load_cell.tare().await;
 
     loop {
         // Get current device state

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ async fn main(spawner: Spawner) -> ! {
     // Allocate 72KB of heap memory
     esp_alloc::heap_allocator!(size: 72 * 1024);
 
-    debug!("{}", Hx711::get_calibration().unwrap());
+    debug!("{}", Hx711::get_calibration_factor().unwrap());
 
     // Initialize BLE controller
     let timg0 = TimerGroup::new(peripherals.TIMG0);
@@ -236,7 +236,7 @@ async fn measurement_task(
             }
             MeasurementTaskStatus::DefaultCalibration => {
                 // Reset calibration to default values
-                if let Err(e) = load_cell.default_calibration() {
+                if let Err(e) = load_cell.default_calibration_factor() {
                     error!(
                         "Error applying default calibration: {:?}",
                         defmt::Debug2Format(&e)

--- a/src/progressor.rs
+++ b/src/progressor.rs
@@ -167,7 +167,10 @@ impl ControlOpCode {
                 DataPoint::from(response).send(channel);
             }
             ControlOpCode::GetCalibration => {
-                info!("GetCalibration: {:?}", Hx711::get_calibration().unwrap());
+                info!(
+                    "GetCalibration: {:?}",
+                    Hx711::get_calibration_factor().unwrap()
+                );
             }
             ControlOpCode::AddCalibrationPoint => {
                 if data.len() < 5 {


### PR DESCRIPTION
Instead, we tare the scale when initializing it, not sure if this is the best approach as we may tare it with already some weight (it can be always re-tared from any of the apps, though)